### PR TITLE
Add tests and improve documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,5 @@ License: What license is it under?
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
+Suggests: 
+    testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,8 +7,9 @@ Maintainer: The package maintainer <yourself@somewhere.net>
 Description: More about what it does (maybe more than one line)
     Use four spaces when indenting paragraphs within the Description.
 License: What license is it under?
+Suggests: 
+    testthat
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
-Suggests: 
-    testthat
+Roxygen: list(markdown = TRUE)

--- a/R/fd_plots.R
+++ b/R/fd_plots.R
@@ -3,13 +3,24 @@
 
 #' Return the plots table.
 #'
-#' @return A `data.frame`.
+#' @details The columns are as follows:
+#' - `Replicate` (character): Replicate code. Each replicate contains
+#'   multiple plots with different disturbance treatments.
+#' - `Plot` (integer): Plot ID number. Plots are nested within replicates.
+#' - `Latitude`, `Longitude` (double): Plot coordinates, in decimal
+#'   degrees.
+#' - `Disturbance_severity` (double): Level of disturbance severity,
+#'   expressed as a percent (0 - 100) reduction in the target variable (TBD).
+#'
+#' @return A `data.frame`. See "Details" for column descriptions.
 #' @export
 #'
 #' @examples
 #' fd_plots()
 fd_plots <- function() {
   read.csv(
-    system.file("extdata", "fd_plots.csv", package = "fortedata", mustWork = TRUE)
+    system.file("extdata", "fd_plots.csv",
+                package = "fortedata", mustWork = TRUE),
+    stringsAsFactors = FALSE
   )
 }

--- a/inst/extdata/fd_plots.csv
+++ b/inst/extdata/fd_plots.csv
@@ -1,4 +1,4 @@
-Replicate,Plot	,Longitude,Latitude,Disturbance_severity
+Replicate,Plot,Longitude,Latitude,Disturbance_severity
 A,1,-100,47,0
 A,2,-100,47,45
 A,3,-100,47,65

--- a/man/fd_plots.Rd
+++ b/man/fd_plots.Rd
@@ -7,10 +7,20 @@
 fd_plots()
 }
 \value{
-A `data.frame`.
+A `data.frame`. See "Details" for column descriptions.
 }
 \description{
 Return the plots table.
+}
+\details{
+The columns are as follows:
+- `Replicate` (character): Replicate code. Each replicate contains
+  multiple plots with different disturbance treatments.
+- `Plot` (integer): Plot ID number. Plots are nested within replicates.
+- `Latitude`, `Longitude` (double): Plot coordinates, in decimal
+  degrees.
+- `Disturbance_severity` (double): Level of disturbance severity,
+  expressed as a percent (0 - 100) reduction in the target variable (TBD).
 }
 \examples{
 fd_plots()

--- a/man/fd_plots.Rd
+++ b/man/fd_plots.Rd
@@ -7,20 +7,22 @@
 fd_plots()
 }
 \value{
-A `data.frame`. See "Details" for column descriptions.
+A \code{data.frame}. See "Details" for column descriptions.
 }
 \description{
 Return the plots table.
 }
 \details{
 The columns are as follows:
-- `Replicate` (character): Replicate code. Each replicate contains
-  multiple plots with different disturbance treatments.
-- `Plot` (integer): Plot ID number. Plots are nested within replicates.
-- `Latitude`, `Longitude` (double): Plot coordinates, in decimal
-  degrees.
-- `Disturbance_severity` (double): Level of disturbance severity,
-  expressed as a percent (0 - 100) reduction in the target variable (TBD).
+\itemize{
+\item \code{Replicate} (character): Replicate code. Each replicate contains
+multiple plots with different disturbance treatments.
+\item \code{Plot} (integer): Plot ID number. Plots are nested within replicates.
+\item \code{Latitude}, \code{Longitude} (double): Plot coordinates, in decimal
+degrees.
+\item \code{Disturbance_severity} (double): Level of disturbance severity,
+expressed as a percent (0 - 100) reduction in the target variable (TBD).
+}
 }
 \examples{
 fd_plots()

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(fortedata)
+
+test_check("fortedata")

--- a/tests/testthat/test.fd_plots.R
+++ b/tests/testthat/test.fd_plots.R
@@ -1,0 +1,6 @@
+context("Loading internal package data")
+
+test_that("Plots table", {
+  dat <- fd_plots()
+  expect_s3_class(dat, "data.frame")
+})

--- a/tests/testthat/test.fd_plots.R
+++ b/tests/testthat/test.fd_plots.R
@@ -3,4 +3,22 @@ context("Loading internal package data")
 test_that("Plots table", {
   dat <- fd_plots()
   expect_s3_class(dat, "data.frame")
+
+  with(dat, {
+    # UMBS is around 45, -85. This sets a very comfortable bounding
+    # box around that, which we should shrink later.
+    expect_true(all(Latitude > 40))
+    expect_true(all(Latitude < 50))
+    expect_true(all(Longitude > -180))
+    expect_true(all(Longitude < 0))
+
+    expect_true(all(Disturbance_severity >= 0))
+    expect_true(all(Disturbance_severity <= 100))
+
+    expect_type(Plot, "integer")
+    expect_type(Replicate, "character") # factor?
+  })
+
+  # Plot x Replicate should be unique
+  expect_equal(nrow(unique(dat[, c("Plot", "Replicate")])), nrow(dat))
 })


### PR DESCRIPTION
- Configure `testthat` tests, and write some basic sanity checks for `fd_plots`
- Allow markdown in Roxygen comments. This makes it much easier to write nicely formatted documentation
- First pass at more detailed descriptions of columns in `fd_plots`
- Set `stringsAsFactors = FALSE` in `fd_plots`. If we want these to be factors that work reliably, we should set the levels explicitly ourselves (see #2).