### PR TITLE
Only print startup message occasionally

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,12 +1,5 @@
 .onAttach <- function(libname, pkgname) {
-  packageStartupMessage("Thanks for using the fortedata package")
-
-  packageStartupMessage("Please cite the package as:
-
-Atkins JW, Agee E, Barry A, Dahlin KM, Dorheim K, Grigri MS, Haber LT, Hickey
-LJ, Kamoske AG, Mathes K, McGuigan C, Paris E, Pennington SC, Rodriguez C,
-Shafer A, Shiklomanov A, Tallant J, Gough CM, Bond-Lamberty B (2020). The
-fortedata R package: open-science datasets from a manipulative experiment
-testing forest resilience. R package version 1.0.1, <URL:
-https://github.com/FoRTExperiment/fortedata>.")
+  if(runif(1) < 0.25) {
+    packageStartupMessage("Thanks for using fortedata. Please cite the package correctly! See citation('fortedata')")
+  }
 }


### PR DESCRIPTION
`fortedata` is chatty, printing a very long message every single time it's attached. This seems like not best practice to me; this PR (totally optional @atkinsjeff ) changes it to a single line printed every 1 of 4 invocations.