### PR TITLE
Adding a badge to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,10 @@ devtools::install_github("FoRTExperiment/fortedata", dependencies = TRUE, build_
 * Research Collaborators: Elizabeth Agee, Brandon Alveshare, Kyla M. Dahlin, Robert T. Fahey, Aaron G. Kamoske, Jason Tallant
 
 
+### STATUS BADGE 
+
+
+![](https://github.com/FoRTExperiment/fortedata/actions/workflows/test-coverage.yaml/badge.svg)
+
+
+


### PR DESCRIPTION
Based on the instructions given at (https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge), I attempted to add a badge to our readme file. If this works, it should display whether our "test-coverage" workflow is functioning. Should we add a second badge for the check-standard workflow?